### PR TITLE
Remove lambda.zip from build area

### DIFF
--- a/builders/dotnet.go
+++ b/builders/dotnet.go
@@ -72,6 +72,7 @@ hook-package() {
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
   mv lambda.zip /tmp/task/lambda.zip
+  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /var/task

--- a/builders/go.go
+++ b/builders/go.go
@@ -75,6 +75,7 @@ hook-package() {
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip bootstrap
   mv lambda.zip /tmp/task/lambda.zip
+  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /go/src/handler

--- a/builders/nodejs.go
+++ b/builders/nodejs.go
@@ -72,6 +72,7 @@ hook-package() {
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
   mv lambda.zip /tmp/task/lambda.zip
+  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /var/task

--- a/builders/python.go
+++ b/builders/python.go
@@ -146,6 +146,7 @@ hook-package() {
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
   mv lambda.zip /tmp/task/lambda.zip
+  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /var/task

--- a/builders/ruby.go
+++ b/builders/ruby.go
@@ -73,6 +73,7 @@ hook-package() {
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
   mv lambda.zip /tmp/task/lambda.zip
+  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /var/task


### PR DESCRIPTION
This is no longer needed and may be undesired if the /var/task directory is mounted for later use.