### PR TITLE
Build a docker image based on the built workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Alternatively, a given path can be specified via the `--working-directory` flag:
 lambda-builder build --working-directory path/to/app
 ```
 
+In addition to the `lambda.yml`, a docker image can be produced from the generated artifact by specifying the `--build-image` flag. This also allows for multiple `--label`  flags as well as specifying a single image tag via either `-t` or `--tag`:
+
+```shell
+# will write a lambda.zip in the specified path
+# and generate a docker image named `lambda-builder:$APP:latest`
+# where $APP is the last portion of the working directory
+lambda-builder build --build-image
+
+# adds the labels com.example/key=value and com.example/another-key=value
+lambda-builder build --build-image --label com.example/key=value --label com.example/another-key=value
+
+# tags the image as app/awesome:1234
+lambda-builder build --build-image --tag app/awesome:1234
+```
+
 ### How does it work
 
 Internally, `lambda-builder` detects a given language and builds the app according to the script specified by the detected builder within a disposablecontainer environment emulating AWS Lambda. If a builder is not detected, the build will fail. The following languages are supported:
@@ -80,16 +95,22 @@ Internally, `lambda-builder` detects a given language and builds the app accordi
 
 When the app is built, a `lambda.zip` will be produced in the specified working directory. The resulting `lambda.zip` can be uploaded to S3 and used within a Lambda function.
 
-Both the builder and the build image environment can be overriden in an optional `lambda.yml` file in the specified working directory. An example of this file is as follows:
+Both the builder and the build image environment can be overriden in an optional `lambda.yml` file in the specified working directory.
+
+### `lambda.yml`
+
+The following a short description of the `lambda.yml` format.
 
 ```yaml
 ---
 build_image: mlupin/docker-lambda:dotnetcore3.1-build
 builder: dotnet
+run_image: mlupin/docker-lambda:dotnetcore3.1
 ```
 
 - `build_image`: A docker image that is accessible by the docker daemon. The `build_image` _should_ be based on an existing Lambda image - builders may fail if they cannot run within the specified `build_image`. The build will fail if the image is inaccessible by the docker daemon.
 - `builder`: The name of a builder. This may be used if multiple builders match and a specific builder is desired. If an invalid builder is specified, the build will fail.
+- `run_image`: A docker image that is accessible by the docker daemon. The `run_image` _should_ be based on an existing Lambda image - built images may fail to start if they are not compatible with the produced artifact. The generation of the `run` iage will fail if the image is inaccessible by the docker daemon.
 
 ### Deploying
 

--- a/builders/dotnet.go
+++ b/builders/dotnet.go
@@ -8,7 +8,12 @@ type DotnetBuilder struct {
 
 func NewDotnetBuilder(config Config) (DotnetBuilder, error) {
 	var err error
-	config.BuildImage, err = getBuilder(config, "mlupin/docker-lambda:dotnet6-build")
+	config.BuilderBuildImage, err = getBuildImage(config, "mlupin/docker-lambda:dotnet6-build")
+	if err != nil {
+		return DotnetBuilder{}, err
+	}
+
+	config.BuilderRunImage, err = getRunImage(config, "mlupin/docker-lambda:dotnet6")
 	if err != nil {
 		return DotnetBuilder{}, err
 	}
@@ -19,11 +24,7 @@ func NewDotnetBuilder(config Config) (DotnetBuilder, error) {
 }
 
 func (b DotnetBuilder) BuildImage() string {
-	return b.Config.BuildImage
-}
-
-func (b DotnetBuilder) GetConfig() Config {
-	return b.Config
+	return b.Config.BuilderBuildImage
 }
 
 func (b DotnetBuilder) Detect() bool {
@@ -35,7 +36,15 @@ func (b DotnetBuilder) Detect() bool {
 }
 
 func (b DotnetBuilder) Execute() error {
-	return executeBuilder(b.script(), b.Config)
+	return executeBuilder(b.script(), b.GetTaskBuildDir(), b.Config)
+}
+
+func (b DotnetBuilder) GetConfig() Config {
+	return b.Config
+}
+
+func (b DotnetBuilder) GetTaskBuildDir() string {
+	return "/var/task"
 }
 
 func (b DotnetBuilder) Name() string {

--- a/builders/go.go
+++ b/builders/go.go
@@ -8,7 +8,12 @@ type GoBuilder struct {
 
 func NewGoBuilder(config Config) (GoBuilder, error) {
 	var err error
-	config.BuildImage, err = getBuilder(config, "lambci/lambda:build-go1.x")
+	config.BuilderBuildImage, err = getBuildImage(config, "lambci/lambda:build-go1.x")
+	if err != nil {
+		return GoBuilder{}, err
+	}
+
+	config.BuilderRunImage, err = getRunImage(config, "mlupin/docker-lambda:provided.al2")
 	if err != nil {
 		return GoBuilder{}, err
 	}
@@ -19,11 +24,7 @@ func NewGoBuilder(config Config) (GoBuilder, error) {
 }
 
 func (b GoBuilder) BuildImage() string {
-	return b.Config.BuildImage
-}
-
-func (b GoBuilder) GetConfig() Config {
-	return b.Config
+	return b.Config.BuilderBuildImage
 }
 
 func (b GoBuilder) Detect() bool {
@@ -35,7 +36,15 @@ func (b GoBuilder) Detect() bool {
 }
 
 func (b GoBuilder) Execute() error {
-	return executeBuilder(b.script(), b.Config)
+	return executeBuilder(b.script(), b.GetTaskBuildDir(), b.Config)
+}
+
+func (b GoBuilder) GetConfig() Config {
+	return b.Config
+}
+
+func (b GoBuilder) GetTaskBuildDir() string {
+	return "/go/src/handler"
 }
 
 func (b GoBuilder) Name() string {

--- a/builders/nodejs.go
+++ b/builders/nodejs.go
@@ -8,7 +8,12 @@ type NodejsBuilder struct {
 
 func NewNodejsBuilder(config Config) (NodejsBuilder, error) {
 	var err error
-	config.BuildImage, err = getBuilder(config, "mlupin/docker-lambda:nodejs14.x-build")
+	config.BuilderBuildImage, err = getBuildImage(config, "mlupin/docker-lambda:nodejs14.x-build")
+	if err != nil {
+		return NodejsBuilder{}, err
+	}
+
+	config.BuilderRunImage, err = getRunImage(config, "mlupin/docker-lambda:nodejs14.x")
 	if err != nil {
 		return NodejsBuilder{}, err
 	}
@@ -19,11 +24,7 @@ func NewNodejsBuilder(config Config) (NodejsBuilder, error) {
 }
 
 func (b NodejsBuilder) BuildImage() string {
-	return b.Config.BuildImage
-}
-
-func (b NodejsBuilder) GetConfig() Config {
-	return b.Config
+	return b.Config.BuilderBuildImage
 }
 
 func (b NodejsBuilder) Detect() bool {
@@ -35,7 +36,15 @@ func (b NodejsBuilder) Detect() bool {
 }
 
 func (b NodejsBuilder) Execute() error {
-	return executeBuilder(b.script(), b.Config)
+	return executeBuilder(b.script(), b.GetTaskBuildDir(), b.Config)
+}
+
+func (b NodejsBuilder) GetConfig() Config {
+	return b.Config
+}
+
+func (b NodejsBuilder) GetTaskBuildDir() string {
+	return "/var/task"
 }
 
 func (b NodejsBuilder) Name() string {

--- a/builders/ruby.go
+++ b/builders/ruby.go
@@ -8,7 +8,12 @@ type RubyBuilder struct {
 
 func NewRubyBuilder(config Config) (RubyBuilder, error) {
 	var err error
-	config.BuildImage, err = getBuilder(config, "mlupin/docker-lambda:ruby2.7-build")
+	config.BuilderBuildImage, err = getBuildImage(config, "mlupin/docker-lambda:ruby2.7-build")
+	if err != nil {
+		return RubyBuilder{}, err
+	}
+
+	config.BuilderRunImage, err = getRunImage(config, "mlupin/docker-lambda:ruby2.7")
 	if err != nil {
 		return RubyBuilder{}, err
 	}
@@ -19,11 +24,7 @@ func NewRubyBuilder(config Config) (RubyBuilder, error) {
 }
 
 func (b RubyBuilder) BuildImage() string {
-	return b.Config.BuildImage
-}
-
-func (b RubyBuilder) GetConfig() Config {
-	return b.Config
+	return b.Config.BuilderBuildImage
 }
 
 func (b RubyBuilder) Detect() bool {
@@ -34,8 +35,16 @@ func (b RubyBuilder) Detect() bool {
 	return false
 }
 
+func (b RubyBuilder) GetConfig() Config {
+	return b.Config
+}
+
+func (b RubyBuilder) GetTaskBuildDir() string {
+	return "/var/task"
+}
+
 func (b RubyBuilder) Execute() error {
-	return executeBuilder(b.script(), b.Config)
+	return executeBuilder(b.script(), b.GetTaskBuildDir(), b.Config)
 }
 
 func (b RubyBuilder) Name() string {

--- a/commands/build.go
+++ b/commands/build.go
@@ -19,6 +19,9 @@ import (
 type BuildCommand struct {
 	command.Meta
 
+	buildImage       bool
+	imageTag         string
+	labels           []string
 	quiet            bool
 	workingDirectory string
 }
@@ -63,7 +66,10 @@ func (c *BuildCommand) FlagSet() *flag.FlagSet {
 
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.BoolVar(&c.quiet, "quiet", false, "run builder in quiet mode")
+	f.BoolVar(&c.buildImage, "build-image", false, "build a docker image")
+	f.StringVarP(&c.imageTag, "tag", "t", "", "name and optionally a tag in the 'name:tag' format")
 	f.StringVar(&c.workingDirectory, "working-directory", workingDirectory, "working directory")
+	f.StringArrayVar(&c.labels, "label", []string{}, " set metadata for an image")
 	return f
 }
 
@@ -71,8 +77,8 @@ func (c *BuildCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--count": complete.PredictNothing,
-			"--quiet": complete.PredictNothing,
+			"--build-image": complete.PredictNothing,
+			"--quiet":       complete.PredictNothing,
 		},
 	)
 }
@@ -111,7 +117,10 @@ func (c *BuildCommand) Run(args []string) int {
 
 	identifier := uuid.New().String()
 	config := builders.Config{
+		BuildImage:       c.buildImage,
 		Identifier:       identifier,
+		ImageLabels:      c.labels,
+		ImageTag:         c.imageTag,
 		RunQuiet:         c.quiet,
 		WorkingDirectory: c.workingDirectory,
 	}


### PR DESCRIPTION
This will allow users to locally test the built artifact. Note that they'll still need to specify a handler as the command for the container, as this isn't written to the image at this time.

Closes #4.