### PR TITLE
Release 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = lambda-builder
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.2.0
+BASE_VERSION ?= 0.3.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = lambda-builder
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.1.0
+BASE_VERSION ?= 0.2.0
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ I don't want to go through the motions of figuring out the correct way to build 
 
 ```shell
 # substitute the version number as desired
-go build -ldflags "-X main.Version=0.2.0
+go build -ldflags "-X main.Version=0.3.0
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -55,33 +55,33 @@ lambda-builder build --build-env KEY=VALUE --build-env ANOTHER_KEY=some-value
 
 #### Building an image
 
-A docker image can be produced from the generated artifact by specifying the `--build-image` flag. This also allows for multiple `--label`  flags as well as specifying a single image tag via either `-t` or `--tag`:
+A docker image can be produced from the generated artifact by specifying the `--generate-image` flag. This also allows for multiple `--label`  flags as well as specifying a single image tag via either `-t` or `--tag`:
 
 ```shell
 # will write a lambda.zip in the specified path
 # and generate a docker image named `lambda-builder:$APP:latest`
 # where $APP is the last portion of the working directory
-lambda-builder build --build-image
+lambda-builder build --generate-image
 
 # adds the labels com.example/key=value and com.example/another-key=value
-lambda-builder build --build-image --label com.example/key=value --label com.example/another-key=value
+lambda-builder build --generate-image --label com.example/key=value --label com.example/another-key=value
 
 # tags the image as app/awesome:1234
-lambda-builder build --build-image --tag app/awesome:1234
+lambda-builder build --generate-image --tag app/awesome:1234
 ```
 
 By default, any web process started by the built image starts on port `9001`. This can be overriden via the `--port` environment variable.
 
 ```shell
 # build the image and ensure it starts on port 5000 by default
-lambda-builder build --build-image --port 5000
+lambda-builder build --generate-image --port 5000
 ````
 
 Custom environment variables can be supplied for the built image by specifying one or more `--image-env` flags. The `--image-env` flag takes `KEY=VALUE` pairs.
 
 ```shell
 # the built image will have `ENV` directives corresponding to the values specified by `--image-env`
-lambda-builder build --build-image --image-env KEY=VALUE --image-env ANOTHER_KEY=some-value
+lambda-builder build --generate-image --image-env KEY=VALUE --image-env ANOTHER_KEY=some-value
 ```
 
 #### Generating a Procfile

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Custom environment variables can be supplied for the build environment by specif
 lambda-builder build --build-env KEY=VALUE --build-env ANOTHER_KEY=some-value
 ```
 
+A `builder` can be chosen by a flag. Note that while a `builder` may be selected, the detection for that builder must still pass in order for the build to succeed.
+
+```shell
+lambda-builder build --generate-image --builder dotnet
+````
+
 #### Building an image
 
 A docker image can be produced from the generated artifact by specifying the `--generate-image` flag. This also allows for multiple `--label`  flags as well as specifying a single image tag via either `-t` or `--tag`:
@@ -83,6 +89,12 @@ Custom environment variables can be supplied for the built image by specifying o
 # the built image will have `ENV` directives corresponding to the values specified by `--image-env`
 lambda-builder build --generate-image --image-env KEY=VALUE --image-env ANOTHER_KEY=some-value
 ```
+
+The `build-image` and `run-image` can also be specified as flags:
+
+```shell
+lambda-builder build --generate-image --build-image "mlupin/docker-lambda:dotnetcore3.1-build" --run-image "mlupin/docker-lambda:dotnetcore3.1"
+````
 
 A generated image can be run locally with the following line:
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Internally, `lambda-builder` detects a given language and builds the app accordi
     - dotnetcore3.1
 - `go`
   - default build image: `lambci/lambda:build-go1.x`
-  - requirement: `go.mod`
+  - requirement: `go.mod` or `main.go`
   - runtimes:
     - provided.al2
 - `nodejs`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Available commands are:
     version    Return the version of the binary
 ```
 
-### Building an image
+### Building an app
 
 To build an app:
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ Custom environment variables can be supplied for the built image by specifying o
 lambda-builder build --generate-image --image-env KEY=VALUE --image-env ANOTHER_KEY=some-value
 ```
 
+A generated image can be run locally with the following line:
+
+```shell
+# run the container and ensure it stays open
+# replace `$APP` with your folder name
+docker run --rm -it -e DOCKER_LAMBDA_STAY_OPEN=1 -p 9001:9001 "lambda-builder:$APP:latest"
+
+# invoke it using the awscli (v2)
+# note that the function name in this example is `function.handler`
+aws lambda invoke --endpoint http://localhost:9001 --no-sign-request --function-name function.handler --payload '{}' --cli-binary-format raw-in-base64-out output.json
+
+# invoke it via curl
+curl -d '{}' http://localhost:9001/2015-03-31/functions/function.handler/invocations
+```
+
 #### Generating a Procfile
 
 A `Procfile` can be written to the working directory by specifying the `--write-procfile` flag. This file will not be written if one already exists in the working directory. If an image is being built, the detected handler will also be injected into the build context and used as the default `CMD` for the image. The contents of the `Procfile` are a `web` process type and a detected handler.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ I don't want to go through the motions of figuring out the correct way to build 
 
 ```shell
 # substitute the version number as desired
-go build -ldflags "-X main.Version=0.1.0
+go build -ldflags "-X main.Version=0.2.0
 ```
 
 ## Usage

--- a/builders/go.go
+++ b/builders/go.go
@@ -24,7 +24,11 @@ func NewGoBuilder(config Config) (GoBuilder, error) {
 }
 
 func (b GoBuilder) Detect() bool {
-	if io.FileExistsInDirectory(b.Config.WorkingDirectory, "go.sum") {
+	if io.FileExistsInDirectory(b.Config.WorkingDirectory, "go.mod") {
+		return true
+	}
+
+	if io.FileExistsInDirectory(b.Config.WorkingDirectory, "main.go") {
 		return true
 	}
 
@@ -76,8 +80,13 @@ puts-step() {
 }
 
 install-gomod() {
-  puts-step "Downloading dependencies via go mod"
-  go mod download 2>&1 | indent
+  if [[ -f "go.mod" ]]; then
+    puts-step "Downloading dependencies via go mod"
+    go mod download 2>&1 | indent
+  else
+    puts-step "Missing go.mod, downloading dependencies via go get"
+    go get
+  fi
 
   puts-step "Compiling via go build"
   go build -o bootstrap main.go 2>&1 | indent

--- a/builders/main.go
+++ b/builders/main.go
@@ -26,9 +26,10 @@ type Builder interface {
 
 type Config struct {
 	BuildEnv          []string
-	GenerateImage     bool
+	Builder           string
 	BuilderBuildImage string
 	BuilderRunImage   string
+	GenerateImage     bool
 	Handler           string
 	HandlerMap        map[string]string
 	Identifier        string
@@ -37,8 +38,8 @@ type Config struct {
 	ImageTag          string
 	Port              int
 	RunQuiet          bool
-	WriteProcfile     bool
 	WorkingDirectory  string
+	WriteProcfile     bool
 }
 
 func (c Config) GetImageTag() string {

--- a/builders/main.go
+++ b/builders/main.go
@@ -26,7 +26,7 @@ type Builder interface {
 
 type Config struct {
 	BuildEnv          []string
-	BuildImage        bool
+	GenerateImage     bool
 	BuilderBuildImage string
 	BuilderRunImage   string
 	Handler           string
@@ -89,7 +89,7 @@ func executeBuilder(script string, taskBuildDir string, config Config) error {
 		}
 	}
 
-	if config.BuildImage {
+	if config.GenerateImage {
 		fmt.Printf("=====> Building image\n")
 		fmt.Printf("       Generating temporary Dockerfile\n")
 		if err := generateDockerfile(handler, tmp, config); err != nil {

--- a/commands/build.go
+++ b/commands/build.go
@@ -87,12 +87,17 @@ func (c *BuildCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--build-env":      complete.PredictAnything,
-			"--generate-image": complete.PredictNothing,
-			"--image-env":      complete.PredictAnything,
-			"--port":           complete.PredictAnything,
-			"--quiet":          complete.PredictNothing,
-			"--write-procfile": complete.PredictNothing,
+			"--build-env":         complete.PredictAnything,
+			"--generate-image":    complete.PredictNothing,
+			"--handler":           complete.PredictAnything,
+			"--image-env":         complete.PredictAnything,
+			"--label":             complete.PredictAnything,
+			"--port":              complete.PredictAnything,
+			"--quiet":             complete.PredictNothing,
+			"-t":                  complete.PredictAnything,
+			"--tag":               complete.PredictAnything,
+			"--working-directory": complete.PredictAnything,
+			"--write-procfile":    complete.PredictNothing,
 		},
 	)
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -20,7 +20,7 @@ type BuildCommand struct {
 	command.Meta
 
 	buildEnv         []string
-	buildImage       bool
+	generateImage    bool
 	handler          string
 	imageEnv         []string
 	imageTag         string
@@ -70,7 +70,7 @@ func (c *BuildCommand) FlagSet() *flag.FlagSet {
 	}
 
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
-	f.BoolVar(&c.buildImage, "build-image", false, "build a docker image")
+	f.BoolVar(&c.generateImage, "generate-image", false, "build a docker image")
 	f.BoolVar(&c.quiet, "quiet", false, "run builder in quiet mode")
 	f.BoolVar(&c.writeProcfile, "write-procfile", false, "writes a Procfile if a handler is specified or detected")
 	f.IntVar(&c.port, "port", -1, "set the default port for the lambda to listen on")
@@ -88,7 +88,7 @@ func (c *BuildCommand) AutocompleteFlags() complete.Flags {
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
 			"--build-env":      complete.PredictAnything,
-			"--build-image":    complete.PredictNothing,
+			"--generate-image": complete.PredictNothing,
 			"--image-env":      complete.PredictAnything,
 			"--port":           complete.PredictAnything,
 			"--quiet":          complete.PredictNothing,
@@ -132,7 +132,7 @@ func (c *BuildCommand) Run(args []string) int {
 	identifier := uuid.New().String()
 	config := builders.Config{
 		BuildEnv:         c.buildEnv,
-		BuildImage:       c.buildImage,
+		GenerateImage:    c.generateImage,
 		Identifier:       identifier,
 		ImageEnv:         c.imageEnv,
 		ImageLabels:      c.labels,

--- a/test.bats
+++ b/test.bats
@@ -34,6 +34,13 @@ teardown_file() {
   [[ "$status" -eq 0 ]]
 }
 
+@test "[build] go without go modules" {
+  run $LAMBDA_BUILDER_BIN build --working-directory tests/go-nomod
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+}
+
 @test "[build] hooks" {
   run $LAMBDA_BUILDER_BIN build --working-directory tests/hooks
   echo "output: $output"

--- a/tests/go-nomod/main.go
+++ b/tests/go-nomod/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type MyEvent struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
+	return fmt.Sprintf("Hello %s!", name.Name), nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/tests/go-nomod/test.bats
+++ b/tests/go-nomod/test.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+export LAMBDA_ROLE="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity | jq -r ".Account")"
+export LAMBDA_FUNCTION_NAME=lambda-go1x
+export LAMBDA_RUNTIME=provided.al2
+export LAMBDA_HANDLER=bootstrap
+
+setup() {
+  aws lambda delete-function --function-name "$LAMBDA_FUNCTION_NAME" 2>/dev/null || true
+  aws iam detach-role-policy --role-name "$LAMBDA_FUNCTION_NAME" --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+  aws iam delete-role --role-name "$LAMBDA_FUNCTION_NAME" 2>/dev/null || true
+}
+
+teardown() {
+  aws lambda delete-function --function-name "$LAMBDA_FUNCTION_NAME" 2>/dev/null || true
+  aws iam detach-role-policy --role-name "$LAMBDA_FUNCTION_NAME" --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+  aws iam delete-role --role-name "$LAMBDA_FUNCTION_NAME" 2>/dev/null || true
+}
+
+@test "aws test" {
+  run /bin/bash -c "lambda-builder build"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "aws iam create-role --role-name '$LAMBDA_FUNCTION_NAME' --tags 'Key=app,Value=lambda-builder' --tags 'Key=com.dokku.lambda-builder/runtime,Value=$LAMBDA_RUNTIME'  --assume-role-policy-document '{\"Version\": \"2012-10-17\", \"Statement\": [{ \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Action\": \"sts:AssumeRole\"}]}'"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "aws iam attach-role-policy --role-name '$LAMBDA_FUNCTION_NAME' --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "sleep 10"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "aws lambda create-function --function-name '$LAMBDA_FUNCTION_NAME' --package-type Zip --tags 'app=lambda-builder,com.dokku.lambda-builder/runtime=$LAMBDA_RUNTIME' --role 'arn:aws:iam::${AWS_ACCOUNT_ID}:role/$LAMBDA_FUNCTION_NAME' --zip-file fileb://lambda.zip --runtime '$LAMBDA_RUNTIME' --handler '$LAMBDA_HANDLER'"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "sleep 10"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "aws lambda get-function --function-name '$LAMBDA_FUNCTION_NAME'"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+
+  run /bin/bash -c "aws lambda invoke --cli-binary-format raw-in-base64-out --function-name '$LAMBDA_FUNCTION_NAME' --payload '{\"name\": \"World\"}' response.json"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
- #18: Add example documentation for local testing
- #19: Allow builder, build-image, and run-image to be specified via flag
- #20: Add support for building a go app without any go modules specified