### PR TITLE
Perform app building via docker image

### DIFF
--- a/builders/dotnet.go
+++ b/builders/dotnet.go
@@ -63,10 +63,6 @@ indent() {
   sed -u "s/^/       /"
 }
 
-puts-header() {
-  echo "=====> $*"
-}
-
 puts-step() {
   echo "-----> $*"
 }

--- a/builders/dotnet.go
+++ b/builders/dotnet.go
@@ -99,11 +99,8 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
-  mv lambda.zip /tmp/task/lambda.zip
-  rm -rf lambda.zip
 }
 
-cp -a /tmp/task/. /var/task
 hook-pre-compile
 install-dotnet
 hook-post-compile

--- a/builders/go.go
+++ b/builders/go.go
@@ -113,8 +113,6 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip bootstrap
-  mv lambda.zip /tmp/task/lambda.zip
-  rm -rf lambda.zip
 }
 
 cp -a /tmp/task/. /go/src/handler

--- a/builders/go.go
+++ b/builders/go.go
@@ -115,7 +115,7 @@ hook-package() {
   zip -q -r lambda.zip bootstrap
 }
 
-cp -a /tmp/task/. /go/src/handler
+cp -a /var/task/. /go/src/handler
 hook-pre-compile
 install-gomod
 hook-post-compile

--- a/builders/go.go
+++ b/builders/go.go
@@ -69,10 +69,6 @@ indent() {
   sed -u "s/^/       /"
 }
 
-puts-header() {
-  echo "=====> $*"
-}
-
 puts-step() {
   echo "-----> $*"
 }

--- a/builders/go.go
+++ b/builders/go.go
@@ -113,9 +113,11 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip bootstrap
+  mv lambda.zip /var/task/lambda.zip
 }
 
 cp -a /var/task/. /go/src/handler
+cd /go/src/handler
 hook-pre-compile
 install-gomod
 hook-post-compile

--- a/builders/main.go
+++ b/builders/main.go
@@ -31,7 +31,7 @@ type Config struct {
 	Builder           string
 	BuilderBuildImage string
 	BuilderRunImage   string
-	GenerateImage     bool
+	GenerateRunImage  bool
 	Handler           string
 	HandlerMap        map[string]string
 	Identifier        string
@@ -100,7 +100,7 @@ func executeBuilder(script string, config Config) error {
 		}
 	}
 
-	if config.GenerateImage {
+	if config.GenerateRunImage {
 		fmt.Printf("=====> Building image\n")
 		fmt.Printf("       Generating temporary Dockerfile\n")
 

--- a/builders/main.go
+++ b/builders/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"lambda-builder/io"
 
@@ -118,7 +119,7 @@ func executeBuilder(script string, config Config) error {
 		}
 
 		fmt.Printf("       Executing build of %s\n", config.GetImageTag())
-		if err := buildDockerImage(taskHostBuildDir, config, dockerfilePath); err != nil {
+		if err := buildDockerImage(taskHostBuildDir, config, "run", dockerfilePath); err != nil {
 			return err
 		}
 	}
@@ -127,20 +128,109 @@ func executeBuilder(script string, config Config) error {
 }
 
 func executeBuildContainer(script string, config Config) error {
+	fmt.Printf("       Generating temporary build script\n")
+	scriptPath, err := os.Create(filepath.Join(config.WorkingDirectory, ".lambda-builder"))
+	defer func() {
+		os.Remove(scriptPath.Name())
+	}()
+
+	if err != nil {
+		return fmt.Errorf("error generating temporary build script: %w", err)
+	}
+
+	if _, err := scriptPath.WriteString(strings.TrimSpace(script)); err != nil {
+		return err
+	}
+
+	fmt.Printf("       Generating temporary Dockerfile\n")
+	dockerfilePath, err := ioutil.TempFile("", "lambda-builder")
+	defer func() {
+		os.Remove(dockerfilePath.Name())
+	}()
+
+	if err != nil {
+		return fmt.Errorf("error generating temporary Dockerfile: %w", err)
+	}
+
+	if err := generateBuildDockerfile(config, dockerfilePath, scriptPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("       Executing build of %s\n", config.GetImageTag())
+	if err := buildDockerImage(config.WorkingDirectory, config, "build", dockerfilePath); err != nil {
+		return err
+	}
+
+	defer func() {
+		buildImageTag := fmt.Sprintf("%s-build", config.GetImageTag())
+		fmt.Printf("       Removing build image: %s", buildImageTag)
+		args := []string{
+			"image",
+			"rm",
+			"--force",
+			buildImageTag,
+		}
+		cmd := execute.ExecTask{
+			Args:        args,
+			Command:     "docker",
+			Cwd:         config.WorkingDirectory,
+			StreamStdio: !config.RunQuiet,
+		}
+
+		if _, err := cmd.Execute(); err != nil {
+			fmt.Printf("       Error cleaning up build image: %s", err.Error())
+		}
+	}()
+
+	extractLambdaFromBuildImage(config)
+
+	return nil
+}
+
+func generateBuildDockerfile(config Config, dockerfilePath *os.File, scriptPath *os.File) error {
+	tpl, err := template.New("t1").Parse(`
+FROM {{ .build_image }}
+LABEL com.dokku.lambda-builder/builder={{ .builder_name }}
+ENV LAMBDA_BUILD_ZIP=1
+WORKDIR /var/task
+COPY . /var/task
+{{range .env}}
+ENV {{.}}
+{{end}}
+RUN mv {{ .build_script_name }} /usr/local/bin/build-lambda && \
+	chmod +x /usr/local/bin/build-lambda && \
+	head -n1 /usr/local/bin/build-lambda && \
+	/usr/local/bin/build-lambda
+`)
+	if err != nil {
+		return fmt.Errorf("error generating template: %s", err)
+	}
+
+	data := map[string]interface{}{
+		"build_script_name": filepath.Base(scriptPath.Name()),
+		"env":               config.BuildEnv,
+		"builder":           config.Builder,
+		"build_image":       config.BuilderBuildImage,
+	}
+
+	if err := tpl.Execute(dockerfilePath, data); err != nil {
+		return fmt.Errorf("error writing Dockerfile: %s", err)
+	}
+
+	return nil
+}
+
+func extractLambdaFromBuildImage(config Config) error {
 	args := []string{
 		"container",
 		"run",
 		"--rm",
-		"--env", "LAMBDA_BUILD_ZIP=1",
-		"--label", "com.dokku.lambda-builder/executor=true",
-		"--name", fmt.Sprintf("lambda-builder-executor-%s", config.Identifier),
+		"--label", "com.dokku.lambda-builder/extractor=true",
+		"--name", fmt.Sprintf("lambda-builder-extractor-%s", config.Identifier),
 		"--volume", fmt.Sprintf("%s:/tmp/task", config.WorkingDirectory),
 	}
 
-	for _, envPair := range config.BuildEnv {
-		args = append(args, "--env", envPair)
-	}
-	args = append(args, config.BuilderBuildImage, "/bin/bash", "-c", script)
+	args = append(args, fmt.Sprintf("%s-build", config.GetImageTag()), "/bin/bash", "-c", "mv /var/task/lambda.zip /tmp/task/lambda.zip")
 
 	cmd := execute.ExecTask{
 		Args:        args,
@@ -194,17 +284,24 @@ COPY . /var/task
 	return nil
 }
 
-func buildDockerImage(directory string, config Config, dockerfilePath *os.File) error {
+func buildDockerImage(directory string, config Config, phase string, dockerfilePath *os.File) error {
+	imageTag := config.GetImageTag()
+	if phase == "build" {
+		imageTag = fmt.Sprintf("%s-build", config.GetImageTag())
+	}
+
 	args := []string{
 		"image",
 		"build",
 		"--file", dockerfilePath.Name(),
 		"--progress", "plain",
-		"--tag", config.GetImageTag(),
+		"--tag", imageTag,
 	}
 
-	for _, label := range config.ImageLabels {
-		args = append(args, "--label", label)
+	if phase == "run" {
+		for _, label := range config.ImageLabels {
+			args = append(args, "--label", label)
+		}
 	}
 
 	args = append(args, directory)

--- a/builders/main.go
+++ b/builders/main.go
@@ -113,7 +113,7 @@ func executeBuilder(script string, config Config) error {
 			return fmt.Errorf("error generating temporary Dockerfile: %w", err)
 		}
 
-		if err := generateDockerfile(handler, config, dockerfilePath); err != nil {
+		if err := generateRunDockerfile(handler, config, dockerfilePath); err != nil {
 			return err
 		}
 
@@ -161,7 +161,7 @@ func executeBuildContainer(script string, config Config) error {
 	return nil
 }
 
-func generateDockerfile(cmd string, config Config, dockerfilePath *os.File) error {
+func generateRunDockerfile(cmd string, config Config, dockerfilePath *os.File) error {
 	tpl, err := template.New("t1").Parse(`
 FROM {{ .run_image }}
 {{ if ne .port "-1" }}

--- a/builders/nodejs.go
+++ b/builders/nodejs.go
@@ -66,10 +66,6 @@ indent() {
   sed -u "s/^/       /"
 }
 
-puts-header() {
-  echo "=====> $*"
-}
-
 puts-step() {
   echo "-----> $*"
 }

--- a/builders/nodejs.go
+++ b/builders/nodejs.go
@@ -102,11 +102,8 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
-  mv lambda.zip /tmp/task/lambda.zip
-  rm -rf lambda.zip
 }
 
-cp -a /tmp/task/. /var/task
 hook-pre-compile
 install-npm
 hook-post-compile

--- a/builders/python.go
+++ b/builders/python.go
@@ -177,11 +177,8 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
-  mv lambda.zip /tmp/task/lambda.zip
-  rm -rf lambda.zip
 }
 
-cp -a /tmp/task/. /var/task
 hook-pre-compile
 
 if [[ -f "requirements.txt" ]]; then

--- a/builders/python.go
+++ b/builders/python.go
@@ -97,10 +97,6 @@ indent() {
   sed -u "s/^/       /"
 }
 
-puts-header() {
-  echo "=====> $*"
-}
-
 puts-step() {
   echo "-----> $*"
 }

--- a/builders/ruby.go
+++ b/builders/ruby.go
@@ -103,11 +103,8 @@ hook-package() {
 
   puts-step "Creating package at lambda.zip"
   zip -q -r lambda.zip ./*
-  mv lambda.zip /tmp/task/lambda.zip
-  rm -rf lambda.zip
 }
 
-cp -a /tmp/task/. /var/task
 hook-pre-compile
 install-bundler
 hook-post-compile

--- a/builders/ruby.go
+++ b/builders/ruby.go
@@ -66,10 +66,6 @@ indent() {
   sed -u "s/^/       /"
 }
 
-puts-header() {
-  echo "=====> $*"
-}
-
 puts-step() {
   echo "-----> $*"
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -22,7 +22,7 @@ type BuildCommand struct {
 	buildEnv         []string
 	builder          string
 	buildImage       string
-	generateImage    bool
+	generateRunImage bool
 	handler          string
 	imageEnv         []string
 	imageTag         string
@@ -73,7 +73,7 @@ func (c *BuildCommand) FlagSet() *flag.FlagSet {
 	}
 
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
-	f.BoolVar(&c.generateImage, "generate-image", false, "build a docker image")
+	f.BoolVar(&c.generateRunImage, "generate-image", false, "build a docker image")
 	f.BoolVar(&c.quiet, "quiet", false, "run builder in quiet mode")
 	f.BoolVar(&c.writeProcfile, "write-procfile", false, "writes a Procfile if a handler is specified or detected")
 	f.IntVar(&c.port, "port", -1, "set the default port for the lambda to listen on")
@@ -149,7 +149,7 @@ func (c *BuildCommand) Run(args []string) int {
 		Builder:           c.builder,
 		BuilderBuildImage: c.buildImage,
 		BuilderRunImage:   c.runImage,
-		GenerateImage:     c.generateImage,
+		GenerateRunImage:  c.generateRunImage,
 		Identifier:        identifier,
 		ImageEnv:          c.imageEnv,
 		ImageLabels:       c.labels,


### PR DESCRIPTION
Rather than start an ephemeral container, generate a Dockerfile and execute the build inside that image.

This provides the ability to take advantage of docker contexts, allowing for remote builds and builds against different architectures. While the ephemeral container provides native cleanup, building images should be done via the normal image build process so folks can depend on their docker daemon to do right correct thing.
