### PR TITLE
Use a newer builder for golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Internally, `lambda-builder` detects a given language and builds the app accordi
     - dotnet6
     - dotnetcore3.1
 - `go`
-  - default build image: `lambci/lambda:build-go1.x`
+  - default build image: `golang:1.21-bookworm`
   - requirement: `go.mod` or `main.go`
   - runtimes:
     - provided.al2

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ lambda-builder build --generate-image --builder dotnet
 
 #### Building an image
 
-A docker image can be produced from the generated artifact by specifying the `--generate-image` flag. This also allows for multiple `--label`  flags as well as specifying a single image tag via either `-t` or `--tag`:
+A docker image can be produced from the generated artifact by specifying the `--generate-image` flag. This also allows for multiple `--label` flags as well as specifying a single image tag via either `-t` or `--tag`:
 
 ```shell
 # will write a lambda.zip in the specified path
@@ -111,7 +111,7 @@ aws lambda invoke --endpoint http://localhost:9001 --no-sign-request --function-
 curl -d '{}' http://localhost:9001/2015-03-31/functions/function.handler/invocations
 
 # the function can also be invoked directly from a container if desired
-docker run --rm "lambda-builder/$APP:latest" function.handler '{"name": "World"}' 
+docker run --rm "lambda-builder/$APP:latest" function.handler '{"name": "World"}'
 ```
 
 #### Generating a Procfile
@@ -141,7 +141,9 @@ Internally, `lambda-builder` detects a given language and builds the app accordi
     - dotnet6
     - dotnetcore3.1
 - `go`
-  - default build image: `golang:1.21-bookworm`
+  - default build image:
+    - With `go.mod`: `golang:1.21-bookworm`
+    - Without `go.mod`: `golang:1.17-buster`
   - requirement: `go.mod` or `main.go`
   - runtimes:
     - provided.al2

--- a/builders/go.go
+++ b/builders/go.go
@@ -84,6 +84,7 @@ install-gomod() {
     go mod download 2>&1 | indent
   else
     puts-step "Missing go.mod, downloading dependencies via go get"
+	go env -w GO111MODULE=off
     go get
   fi
 

--- a/builders/go.go
+++ b/builders/go.go
@@ -8,7 +8,7 @@ type GoBuilder struct {
 
 func NewGoBuilder(config Config) (GoBuilder, error) {
 	var err error
-	config.BuilderBuildImage, err = getBuildImage(config, "lambci/lambda:build-go1.x")
+	config.BuilderBuildImage, err = getBuildImage(config, "golang:1.21-bookworm")
 	if err != nil {
 		return GoBuilder{}, err
 	}
@@ -83,7 +83,7 @@ install-gomod() {
   fi
 
   puts-step "Compiling via go build"
-  go build -o bootstrap main.go 2>&1 | indent
+  CGO_ENABLED=0 go build -o bootstrap main.go 2>&1 | indent
 }
 
 hook-pre-compile() {
@@ -109,6 +109,11 @@ hook-post-compile() {
 hook-package() {
   if [[ "$LAMBDA_BUILD_ZIP" != "1" ]]; then
     return
+  fi
+
+  if ! command -v zip >/dev/null 2>&1; then
+    puts-step "Installing zip dependency for packaging"
+    apt update && apt install -y --no-install-recommends zip
   fi
 
   puts-step "Creating package at lambda.zip"

--- a/builders/go.go
+++ b/builders/go.go
@@ -8,7 +8,12 @@ type GoBuilder struct {
 
 func NewGoBuilder(config Config) (GoBuilder, error) {
 	var err error
-	config.BuilderBuildImage, err = getBuildImage(config, "golang:1.21-bookworm")
+	defaultBuilder := "golang:1.21-bookworm"
+	if !io.FileExistsInDirectory(config.WorkingDirectory, "go.mod") {
+		defaultBuilder = "golang:1.17-bullseye"
+	}
+
+	config.BuilderBuildImage, err = getBuildImage(config, defaultBuilder)
 	if err != nil {
 		return GoBuilder{}, err
 	}


### PR DESCRIPTION
Without this, using newer libraries fails due to the old builder having a now unsupported golang.