### PR TITLE
chore: bump json from 2.15.2.1 to 2.21.2

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Patches CVE-2026-54696 (GHSA-x2f5-4prf-w687), a low-severity heap buffer overflow in the `json` generator's IO-streaming path, resolving Dependabot alert #90.

`json` is a transitive dependency of `package_cloud` used only by the tagged-release workflow to build `.deb` packages, and was pinned in `.github/Gemfile.lock` at `2.15.2.1`, inside the vulnerable range `>= 2.9.0, < 2.19.9`. The new version `2.21.2` is past the first patched release `2.19.9` and satisfies `package_cloud`'s `json (~> 2.9)` constraint. Since `json` has no runtime dependencies, this is a single-line lockfile change equivalent to a conservative `bundle lock --update json`.